### PR TITLE
Security pass: narrow amber SELinux grants, harden papermode.sh against device-data injection

### DIFF
--- a/papermode-quick/papermode.sh
+++ b/papermode-quick/papermode.sh
@@ -26,7 +26,13 @@ BACKUP="$DIR/.papermode_backup"
 
 # --- settings helpers --------------------------------------------------------
 sget() { $ADB shell settings get "$1" "$2" 2>/dev/null | tr -d '\r'; }
-sput() { $ADB shell settings put "$1" "$2" "$3"; }
+# The adb client joins argv with spaces and passes the line to the device
+# shell unescaped (AOSP b/20564385, same as ssh). Single-quote-escape so a
+# value stays ONE settings argument on the device side — otherwise a device
+# settings value (any WRITE_SETTINGS app can poison it) could run as the adb
+# shell uid. `sq` only ever sees validated values, this is defense in depth.
+sq() { local v="$1"; v="${v//\'/\'\\\'\'}"; printf "'%s'\n" "$v"; }
+sput() { $ADB shell settings put "$1" "$2" $(sq "$3"); }
 sdel() { $ADB shell settings delete "$1" "$2" >/dev/null 2>&1 || true; }
 
 require_device() {
@@ -39,11 +45,14 @@ require_device() {
 backup_once() {
   # Only capture originals the first time we turn paper mode on.
   [ -f "$BACKUP" ] && return 0
+  # Stored as `namespace key value` tuples, NOT shell source: the values come
+  # from the device settings DB, which any WRITE_SETTINGS app can poison with
+  # shell metacharacters. We never source this file (see off()).
   {
-    echo "DALT_EN=$(sget secure accessibility_display_daltonizer_enabled)"
-    echo "DALT_MODE=$(sget secure accessibility_display_daltonizer)"
-    echo "MINRR=$(sget system min_refresh_rate)"
-    echo "PEAKRR=$(sget system peak_refresh_rate)"
+    echo "secure accessibility_display_daltonizer_enabled $(sget secure accessibility_display_daltonizer_enabled)"
+    echo "secure accessibility_display_daltonizer $(sget secure accessibility_display_daltonizer)"
+    echo "system min_refresh_rate $(sget system min_refresh_rate)"
+    echo "system peak_refresh_rate $(sget system peak_refresh_rate)"
   } > "$BACKUP"
   echo "Saved originals to $BACKUP"
 }
@@ -97,12 +106,25 @@ off() {
     sdel system peak_refresh_rate
     return 0
   fi
-  # shellcheck disable=SC1090
-  . "$BACKUP"
-  restore_secure accessibility_display_daltonizer_enabled "$DALT_EN"
-  restore_secure accessibility_display_daltonizer "$DALT_MODE"
-  restore_system min_refresh_rate "$MINRR"
-  restore_system peak_refresh_rate "$PEAKRR"
+  # Parse the tuple records; never source device-controlled data as shell,
+  # and restore ONLY the keys this script captured, with validated values —
+  # the backup can carry attacker-planted lines (an embedded newline in a
+  # captured setting splits into extra records) that must not reach adb.
+  while read -r ns key val; do
+    [ -z "$ns" ] && continue
+    case "$ns:$key" in
+      secure:accessibility_display_daltonizer_enabled|secure:accessibility_display_daltonizer|system:min_refresh_rate|system:peak_refresh_rate) ;;
+      *) echo "skipping unlisted backup entry: $ns $key" >&2; continue ;;
+    esac
+    case "$val" in
+      null) ;;   # legit "never set" marker; restore_* deletes the key
+      -*|*[!0-9.]*) echo "skipping non-numeric value for $key; run off again after fixing the device setting" >&2; continue ;;
+    esac
+    case "$ns" in
+      secure) restore_secure "$key" "$val" ;;
+      system) restore_system "$key" "$val" ;;
+    esac
+  done < "$BACKUP"
   rm -f "$BACKUP"
   echo "paper mode OFF (originals restored)"
 }

--- a/sepolicy/dc1amber.te
+++ b/sepolicy/dc1amber.te
@@ -1,25 +1,11 @@
-#
-# SELinux rules for the DC-1 amber frontlight (AmberControl).
-#
-# Writing /sys/class/leds/lcd-backlight-amber/brightness has to clear TWO
-# independent gates:
-#
-#  1. Type enforcement — AmberControl is a platform-signed priv-app, so
-#     seapp_contexts puts it in the `platform_app` domain (not system_app);
-#     the LED nodes are labelled `sysfs_leds`. Hence the allow rules below.
-#
-#  2. MLS — seapp_contexts uses levelFrom=user for app domains, so
-#     platform_app runs at s0:c512,c768 while sysfs_leds nodes sit at s0.
-#     system/sepolicy/private/mls only permits a file write when the target
-#     is app_data_file_type/appdomain_tmpfs, the levels are equal, the source
-#     is mlstrustedsubject, or the target is mlstrustedobject. None held, so
-#     writes returned EACCES even with a perfect allow rule. Marking
-#     sysfs_leds mlstrustedobject closes that gate — same treatment AOSP
-#     already gives sysfs_bluetooth_writable / sysfs_nfc_power_writable.
-#
-# These land in system_ext_sepolicy.cil via SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS
-# (wired in common.mk). Neverallow assertions are off in this GSI
-# (device/phh/treble/base.mk sets SELINUX_IGNORE_NEVERALLOWS := true).
+# Scope: ONLY the sysfs_leds type is touched. A generic-sysfs fallback for
+# /sys/class/backlight/* was removed deliberately — SELinux cannot scope an
+# allow to a path, so granting platform_app write on the generic `sysfs`
+# type would open every unlabelled sysfs node on the tree. On the DC-1 the
+# amber node is /sys/class/leds/lcd-backlight-amber (verified on-device),
+# which is sysfs_leds, so the backlight fallback is dead weight and is
+# dropped. Grants are narrowed to platform_app only, which is the domain
+# AmberControl actually runs in.
 #
 
 typeattribute sysfs_leds mlstrustedobject;
@@ -28,11 +14,8 @@ typeattribute sysfs_leds mlstrustedobject;
 # chmod it; core policy gives init sysfs_leds write but not setattr.
 allow init sysfs_leds:file setattr;
 
-allow { platform_app system_app } sysfs_leds:dir { search open read getattr };
-allow { platform_app system_app } sysfs_leds:lnk_file { read getattr };
-allow { platform_app system_app } sysfs_leds:file { getattr open read write append lock map };
-
-# Fallback: /sys/class/backlight/* is plain sysfs (already mlstrustedobject);
-# only the TE grant is needed there.
-allow { platform_app system_app } sysfs:dir { search open read getattr };
-allow { platform_app system_app } sysfs:file { getattr open read write };
+# AmberControl (platform_app) is the only domain that needs to drive the LED
+# node. It also inspects the class dirs for discovery.
+allow platform_app sysfs_leds:dir { search open read getattr };
+allow platform_app sysfs_leds:lnk_file { read getattr };
+allow platform_app sysfs_leds:file { getattr open read write append lock map };


### PR DESCRIPTION
## Security pass on the DC-1 delta (vs upstream)

Ran a two-model security panel (rev-sec-glm, rev-sec-grok; kimi seat failed — OpenRouter account out of credits, `402 … can only afford 482`) over the fork's on-device delta. Panel verdict: the delta as committed opened policy gates past what the amber feature needs. Two findings corroborated, both fixed here; residuals judged on merit and documented.

### Changes

**`sepolicy/dc1amber.te`** (P1, corroborated)
- Removed the `allow { platform_app system_app } sysfs:{dir,file} …write` fallback entirely. It existed for a `/sys/class/backlight/*` fallback path, but SELinux is type-scoped, not path-scoped — the rule opened write to *every* generically-labelled `sysfs` node on the device, reachable by any app signed with the public AOSP testkey (`platform_app`). The actual amber node is `sysfs_leds` (verified on-device), so the fallback is dead weight.
- Narrowed the `sysfs_leds` grant from `{platform_app system_app}` to `platform_app` only — AmberControl's real domain.

**`papermode-quick/papermode.sh`** (P2)
- Was: `backup_once` wrote device-settings values into a shell file, `off()` sourced it (`. "$BACKUP"`). Any app with user-grantable WRITE_SETTINGS could plant `6; <cmd>` into `min_refresh_rate` → command execution on the *host* shell.
- Now: backups are `namespace key value` tuples, parsed (never sourced) in `off()`, which restores only the four captured keys and rejects any non-null, non-numeric value. Values are also single-quote-escaped at the adb boundary (adb joins argv without escaping — AOSP b/20564385), so a poisoned value stays one settings argument and cannot execute on the device either.

### Verification
- Fake-adb harness: two poison vectors (embedded newline → extra `secure`/`system` records, `; touch …` payload) are skipped by the key allowlist / numeric validator and never reach adb; markers never created. Legit flows (on/off/read) restore correctly, `null` → `settings delete`. Bash syntax clean; `git diff` limited to the two files.
- Targeted re-verify by the same two seats on the fix: policy fix holds (no generic sysfs, no system_app grant, no other delta path grants app domains sysfs); papermode injections closed; both seats' residual P2s (key injection, unquoted adb values) are the two layers added in this PR.

### Judged on merit, not changed
- `0666` DAC on the amber node: the app runs as an install-time app UID unknown to init; TE (`platform_app`, `sysfs_leds`) is the enforcement gate. A non-world mode isn't settable proactively.
- Whole-`sysfs_leds` + `mlstrustedobject` scope: per-node `genfscon` can't reliably shadow platform policy's `/sys/class/leds` prefix in the genfs table from a system_ext module; residual is hardware-bound (one LED node).

Ready for your review pass / build / release.
