### PR TITLE
docs: the DC-1 bootloader draws no unlock UI — confirm blind

### DIFF
--- a/docs/flash.md
+++ b/docs/flash.md
@@ -36,9 +36,10 @@ DC-1 community (daylighthacker.wiki) — the flow below is the standard one.
 ```bash
 # 0) On the device: Developer options → OEM unlocking.
 
-# 1) Boot into the bootloader, unlock
+# 1) Boot into the bootloader, unlock (see the note below — there is no
+#    on-screen prompt; the confirmation is a blind volume-up press)
 adb reboot bootloader
-fastboot flashing unlock            # confirm on screen; wipes data
+fastboot flashing unlock            # wipes data
 
 # 2) Boot fastbootd (userspace fastboot for dynamic partitions)
 fastboot reboot fastboot
@@ -48,6 +49,23 @@ fastboot --disable-verity --disable-verification flash vbmeta vbmeta.img
 fastboot flash system system.img
 fastboot reboot
 ```
+
+> **The bootloader draws no UI — confirm the unlock blind.** `=> FASTBOOT
+> mode...` is the entire display; the unlock prompt other devices show is
+> never drawn on the rLCD. `fastboot flashing unlock` returns `OKAY` after
+> **~5.017 s whether or not it worked** — that five seconds is a silent
+> confirmation window polling for **volume-up**. What works is sending the
+> command in a loop while tapping volume-up:
+>
+> ```bash
+> for i in $(seq 10); do fastboot flashing unlock; done   # tap volume-up throughout
+> ```
+>
+> It landed on attempt 2 here, identifiable because the accepted call
+> **returns in ~0.3 s instead of ~5 s** — that timing is the only feedback
+> you get. Confirm with `fastboot get_unlock_ability`. Nothing else exists on
+> this bootloader: `fastboot oem <anything>` returns `unknown command`, and
+> only `flashing unlock` and `get_unlock_ability` are implemented.
 
 Expected result: LineageOS 23.2 boots, unrooted, amber on by default at full
 (`screen_brightness_amber_rate=1023`), Play Services absent until Phase 2.

--- a/docs/root-walkthrough.md
+++ b/docs/root-walkthrough.md
@@ -32,8 +32,13 @@ LED nodes), fall back to discovery.
 2. Connect adb, then:
    ```bash
    adb reboot bootloader
-   fastboot flashing unlock          # confirm on the screen
+   fastboot flashing unlock          # wipes data
    ```
+   There is **no on-screen prompt** — this bootloader renders no UI at all.
+   The command returns `OKAY` after ~5 s either way; that window is polling
+   for a blind **volume-up** press. Loop the command while tapping volume-up
+   and watch for the call that returns in ~0.3 s. See
+   [`docs/flash.md`](flash.md#phase-1--permanent-install-unlock--flash).
 3. This wipes /data and opens the device to custom images. Stock returns via
    the restore procedure in `docs/flash.md`.
 


### PR DESCRIPTION
From #4 (section 5) — the doc correction I'd rank highest, because without it a new user reasonably concludes the unlock was rejected and stops.

`docs/flash.md` and `docs/root-walkthrough.md` both say to confirm the unlock on screen. On this unit that's impossible: **the bootloader renders no UI at all** — `=> FASTBOOT mode...` is the entire display, and the prompt is never drawn on the rLCD.

What's actually happening:

- `fastboot flashing unlock` returns `OKAY` after **~5.017 s whether or not it worked**. That window is a silent poll for a **volume-up** press.
- Sending the command in a loop while tapping volume-up landed it on **attempt 2**.
- The only feedback is timing: the accepted call **returns in ~0.3 s instead of ~5 s**.
- Nothing else exists on this bootloader — `fastboot oem <anything>` returns `unknown command`; only `flashing unlock` and `get_unlock_ability` are implemented.

Measured on one unit (`jagar` / `vext_jagar`, stock A13 `TP1A.220624.014`). If yours draws a prompt I'd want to know — that would be a bootloader-version difference worth documenting rather than a correction.

Docs only, no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
