### PR TITLE
docs: how to actually get a copy of stock (and two routes that don't work)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ beyond the small documented patches in `patches/`.
 
 None of this substitutes for your own judgement. It's an early release for a
 niche device — read the release notes, verify the checksums, and keep a copy
-of stock on hand.
+of stock on hand ([`docs/stock-recovery.md`](docs/stock-recovery.md) — pull it
+before you unlock).
 
 ## License
 

--- a/docs/flash.md
+++ b/docs/flash.md
@@ -3,9 +3,10 @@
 Two safe phases. Start with DSU (no unlock, no root, reversible) to sanity
 check the image; only then unlock and flash for permanence.
 
-> **Back up first.** A GSI flash replaces the system partition. The stock
-> image can be restored via Daylight's tooling / an OTA zip — have one at
-> hand before unlocking. See daylighthacker.wiki for stock assets.
+> **Back up first.** A GSI flash replaces the system partition. Daylight
+> publishes no firmware images, so pull the stock OTA zip **while the device
+> still boots stock** — see [`docs/stock-recovery.md`](stock-recovery.md).
+> daylighthacker.wiki also collects stock assets.
 
 ## Phase 0 — verify the image with DSU (recommended first step)
 
@@ -84,8 +85,14 @@ re-sparses — one artifact, flashed with the same `fastboot flash system`.
 ## Get back to stock
 
 Reboot to fastbootd and restore the stock `system` (and `vbmeta`) images you
-backed up in the beginning; or use Daylight's OTA tooling
-(adiktofsugar/daylight) to re-image the unit.
+backed up in the beginning.
+
+If you didn't back anything up: Daylight publishes no firmware, but its OTA
+server will hand any registered serial the full OTA zip, which unpacks to the
+images `fastboot` needs. Full procedure — plus the two routes that look
+obvious and fail on this device (`adb root` crash-loops `adbd` here; mtkclient
+is closed on this G99) — in
+[`docs/stock-recovery.md`](stock-recovery.md).
 
 ## Troubleshooting
 

--- a/docs/stock-recovery.md
+++ b/docs/stock-recovery.md
@@ -1,0 +1,74 @@
+# Getting a copy of stock (Sol:OS)
+
+`README.md` and `docs/flash.md` both say to keep a copy of stock on hand
+before unlocking. Daylight publishes no firmware images, so "keep a copy" is
+easier said than done — this is what actually works, and the two obvious
+routes that don't.
+
+## What works: Daylight's own OTA server hands you the full zip
+
+The stock updater (`com.ota.manager`) authenticates against
+`https://updates.daylight.ink` and gets back a pre-signed S3 URL for the
+**complete OTA zip**. Any registered serial can ask for it:
+
+1. `GET /device/time` — server timestamp
+2. RSA-encrypt `<serial>:<timestamp>` with the updater's public key
+3. `POST /device/register` — exchange that for an access token
+4. `POST /device/check-update` — pre-signed S3 URL (valid 12 h)
+5. download
+
+A community implementation lives in
+[`adiktofsugar/daylight`](https://github.com/adiktofsugar/daylight) as
+`download_ota/main.py`, alongside `bin/payload-dumper-go` for unpacking the
+result and a HuggingFace dataset of already-pulled images. That zip is the
+practical "copy of stock" this repo's docs ask for — pull it **before** you
+unlock, while the device still boots stock.
+
+One gotcha when running it: the server only returns an image if you tell it
+the build you're on, and `--os-version` is a MediaTek build string
+(`0.9.9.58.prod.2-1407`), not a date. It is read from `gsm.sn1`, falling back
+to `ro.mediatek.version.release` — **both are system properties, so they read
+empty from inside a DSU or after the GSI flash**. Capture them on stock, or
+pass `--os-version` by hand later.
+
+Unpacked, the zip gives you the `boot`, `vbmeta`, `system`, `vendor` and
+`product` images — i.e. everything `fastboot` needs to put the unit back.
+
+## What doesn't: `adb root` on this GSI
+
+Making your own backup from a running GSI looks obvious and isn't. Lineage's
+**Rooted debugging** toggle restarts `adbd` as uid 0, but it stays in the
+`u:r:adbd:s0` domain with no `su` transition and aborts immediately:
+
+```
+adbd_auth: failed to listen on adbd authentication socket: Permission denied
+```
+
+`adbd` then crash-loops, over USB and TCP alike, so you lose adb entirely.
+Recovery is toggling **Rooted debugging back off** — `adbd` restarts unrooted
+and comes back. No `su` ships in the image either: `/system/xbin/phh-su` is
+referenced by the Treble app but absent on disk.
+
+(This is about the released `user` image. The `--userdebug` build in
+`docs/root-walkthrough.md` is a different thing and does grant `adb root`.)
+
+## What doesn't: mtkclient on this SoC
+
+The usual MediaTek escape hatch is not realistic on the Helio G99 here: the
+BROM is patched and SLA is device-dependent, so the generic exploit path is
+closed. The one community success reported came from asking Daylight support
+directly for a vendor DA file — which is a support ticket, not a procedure.
+
+## Restoring
+
+With the OTA zip unpacked, from fastbootd:
+
+```bash
+fastboot flash system  system.img
+fastboot flash vbmeta  vbmeta.img      # re-enables verification if you want it
+fastboot flash boot    boot.img        # NOTE: this also removes Magisk, if rooted
+fastboot reboot
+```
+
+Flash `boot` only if you actually need it — on a rooted install that is the
+step that drops root, and a system-only restore leaves Magisk in place.


### PR DESCRIPTION
From #4 (section 7).

`README.md` and `docs/flash.md` both tell the user to keep a copy of stock on hand before unlocking, but Daylight publishes no firmware images — so the instruction currently has no procedure behind it. This adds `docs/stock-recovery.md` and points the two existing mentions at it.

**What works:** Daylight's own OTA server hands any registered serial the **full OTA zip** — `/device/time` → RSA-encrypt `serial:timestamp` → `/device/register` for a token → `/device/check-update` → pre-signed S3 URL. Unpacked it gives you `boot`, `vbmeta`, `system`, `vendor`, `product`, i.e. everything fastboot needs.

You already reference `adiktofsugar/daylight` in flash.md; that repo turns out to carry a `download_ota` implementation, `payload-dumper-go` for unpacking, and a HuggingFace dataset of pulled images — so this can be concretely linkable rather than folklore. One gotcha called out in the doc: `--os-version` is a MediaTek build string (`0.9.9.58.prod.2-1407`), read from `gsm.sn1` / `ro.mediatek.version.release` — **both are system properties, so they read empty from inside a DSU or after the GSI flash**. Capture them while still on stock.

**What doesn't**, both measured here, both of which look obvious enough that someone will try them:

- **`adb root` on this GSI.** Lineage's Rooted debugging restarts `adbd` as uid 0 but it stays in `u:r:adbd:s0` with no `su` transition and aborts on `adbd_auth: failed to listen on adbd authentication socket: Permission denied` — then crash-loops, USB and TCP alike, so you lose adb entirely. Recovery is toggling Rooted debugging back off. No `su` ships in the image (`/system/xbin/phh-su` is referenced by the Treble app but absent). The doc notes this is about the released `user` image, not the `--userdebug` build in `root-walkthrough.md`.
- **mtkclient on this G99** — patched BROM, device-dependent SLA; the one community success came from asking Daylight support directly for a vendor DA, which is a support ticket rather than a procedure.

Docs only, no build impact. Happy to trim the community-tooling references if you'd rather not point at them from the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3XjQzaexaB1vA8UsvEUx3