### PR TITLE
dc1: restore the two dead hardware buttons (KEY_F11 / KEY_F12)

### DIFF
--- a/DC1KeyHandler/Android.bp
+++ b/DC1KeyHandler/Android.bp
@@ -1,0 +1,32 @@
+// DC-1 hardware key handler.
+//
+// The DC-1 has two physical buttons (orange side, top) that emit KEY_F11 /
+// KEY_F12 on mtk-kpd. Neither keycode has a default action in AOSP or
+// LineageOS — on stock they worked only because Daylight's own system apps
+// listened for them, so on a GSI both go inert at the flash.
+//
+// Not an app in any user-visible sense: it ships no activity and is never
+// launched. LineageOS' PhoneWindowManager loads the class out of this APK
+// with a PathClassLoader, from the path in config_deviceKeyHandlerLibs (see
+// overlay-lineage/) — the same shape every LineageOS device tree uses for a
+// KeyHandler.
+android_app {
+    name: "DC1KeyHandler",
+    manifest: "AndroidManifest.xml",
+    srcs: ["src/**/*.java"],
+    certificate: "platform",
+    system_ext_specific: true,
+    // Hidden APIs: com.android.internal.os.DeviceKeyHandler (the interface
+    // PWM loads us as), android.util.Slog, android.os.SystemProperties, and
+    // the *ForUser Settings accessors — we run inside system_server.
+    platform_apis: true,
+    optimize: {
+        enabled: false,
+    },
+    dex_preopt: {
+        enabled: false,
+    },
+    lint: {
+        enabled: false,
+    },
+}

--- a/DC1KeyHandler/AndroidManifest.xml
+++ b/DC1KeyHandler/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Carrier for the DeviceKeyHandler class only. No activities, no services, no
+  receivers: PhoneWindowManager loads com.dc1.keyhandler.KeyHandler out of
+  this APK with a PathClassLoader and runs it inside system_server, so nothing
+  here is ever started as an app.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.dc1.keyhandler"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <application
+        android:label="DC1KeyHandler"
+        android:hasCode="true"
+        android:allowBackup="false" />
+</manifest>

--- a/DC1KeyHandler/src/com/dc1/keyhandler/KeyHandler.java
+++ b/DC1KeyHandler/src/com/dc1/keyhandler/KeyHandler.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2026 The DC-1 LineageOS GSI contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dc1.keyhandler;
+
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.PowerManager;
+import android.os.SystemProperties;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.util.Slog;
+import android.view.KeyEvent;
+
+import com.android.internal.os.DeviceKeyHandler;
+
+/**
+ * Restores the DC-1's two physical buttons on a GSI.
+ *
+ * Both buttons emit plain function keys on mtk-kpd (/dev/input/event1):
+ * scancodes 87/88 are mapped to KEY_F11 / KEY_F12 by
+ * /vendor/usr/keylayout/mtk-kpd.kl. Neither keycode has a default action in
+ * AOSP or LineageOS — on stock they were handled by
+ * com.daylightcomputer.systemrunner's KeyHandler, which a GSI replaces, so
+ * both buttons are inert from the flash onwards.
+ *
+ * What stock did (recovered from the stock OTA's SystemRunner.apk,
+ * KeyHandler.handleKeyEvent, resolved against bytecode offsets — the branch
+ * targets invert the obvious reading order, so the disassembly listing alone
+ * attributes the wrong action to each key):
+ *
+ *   F11 (orange, side) -> a toast, "Walkie-Talkie assistant is coming soon!",
+ *                         a stub for a feature Daylight never shipped.
+ *   F12 (top)          -> handleTopButton(): launch com.fluidtouch.noteshelf2,
+ *                         else noteshelf3, else "No note-taking app found".
+ *
+ * F11 therefore has no real behaviour to preserve and is bound here to the
+ * amber frontlight toggle — a physical control findable in the dark beats the
+ * QS tile on a bedside reader. It drives AmberControl's own source of truth
+ * (the Settings.System key), so there is no second mechanism to keep in sync.
+ *
+ * F12 generalises what stock hardcoded: an explicit override if set, else
+ * Android's Notes role (whatever the user's default notes app is), else the
+ * two Noteshelf packages for stock parity.
+ */
+public class KeyHandler implements DeviceKeyHandler {
+
+    private static final String TAG = "DC1KeyHandler";
+
+    /** Orange side button. */
+    private static final int KEY_AMBER_TOGGLE = KeyEvent.KEYCODE_F11;
+    /** Top button. */
+    private static final int KEY_NOTES = KeyEvent.KEYCODE_F12;
+
+    /** Remembers the warmth to come back to when toggling amber back on. */
+    private static final String SETTING_LAST_RATE = "dc1_amber_last_rate";
+    /** Optional explicit target for the top button; unset = Notes role. */
+    private static final String SETTING_NOTES_PACKAGE = "dc1_notes_package";
+
+    private static final String[] STOCK_NOTES_PACKAGES = {
+        "com.fluidtouch.noteshelf2",
+        "com.fluidtouch.noteshelf3",
+    };
+
+    private final Context mContext;
+    private final PowerManager mPowerManager;
+    private final Handler mHandler;
+
+    private final String mAmberSetting;
+    private final int mAmberMax;
+
+    public KeyHandler(Context context) {
+        mContext = context;
+        mPowerManager = context.getSystemService(PowerManager.class);
+
+        // Same knobs the product fragment configures AmberControl with, so the
+        // button can never disagree with the app about scale or key name.
+        mAmberSetting = SystemProperties.get("ro.dc1.amber.setting",
+                "screen_brightness_amber_rate");
+        mAmberMax = SystemProperties.getInt("ro.dc1.amber.max", 1023);
+
+        HandlerThread thread = new HandlerThread("DC1KeyHandler");
+        thread.start();
+        mHandler = new Handler(thread.getLooper());
+    }
+
+    @Override
+    public KeyEvent handleKeyEvent(KeyEvent event) {
+        final int keyCode = event.getKeyCode();
+        if (keyCode != KEY_AMBER_TOGGLE && keyCode != KEY_NOTES) {
+            return event;
+        }
+
+        // Consume both halves of the press so the keycodes never reach apps,
+        // but act once, on the initial down.
+        if (event.getAction() == KeyEvent.ACTION_DOWN && event.getRepeatCount() == 0
+                && mPowerManager.isInteractive()) {
+            // Never do work on the input thread.
+            mHandler.post(keyCode == KEY_AMBER_TOGGLE ? this::toggleAmber : this::openNotes);
+        }
+        return null;
+    }
+
+    /**
+     * Toggle the frontlight between off and the last warmth used.
+     *
+     * AmberControl owns the mix; this only moves its input, so auto-discovery,
+     * the channel model and the watchdog all keep applying.
+     */
+    private void toggleAmber() {
+        final int current = getSetting(mAmberSetting, mAmberMax);
+        final int next;
+        if (current > 0) {
+            putSetting(SETTING_LAST_RATE, current);
+            next = 0;
+        } else {
+            final int remembered = getSetting(SETTING_LAST_RATE, mAmberMax);
+            next = remembered > 0 ? remembered : mAmberMax;
+        }
+        putSetting(mAmberSetting, next);
+        Slog.i(TAG, "orange button -> " + mAmberSetting + "=" + next);
+    }
+
+    /** Open the user's notes app, mirroring what the top button did on stock. */
+    private void openNotes() {
+        final String override = Settings.System.getStringForUser(
+                mContext.getContentResolver(), SETTING_NOTES_PACKAGE,
+                UserHandle.USER_CURRENT);
+        if (override != null && !override.isEmpty() && launchPackage(override)) {
+            return;
+        }
+
+        // The Notes role: routes to whatever the user set as their notes app.
+        final Intent createNote = new Intent(Intent.ACTION_CREATE_NOTE)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        if (startActivity(createNote, "CREATE_NOTE (notes role)")) {
+            return;
+        }
+
+        for (String pkg : STOCK_NOTES_PACKAGES) {
+            if (launchPackage(pkg)) {
+                return;
+            }
+        }
+        Slog.i(TAG, "top button -> no note-taking app found");
+    }
+
+    private boolean launchPackage(String packageName) {
+        final Intent intent = mContext.getPackageManager()
+                .getLaunchIntentForPackage(packageName);
+        if (intent == null) {
+            return false;
+        }
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        return startActivity(intent, packageName);
+    }
+
+    private boolean startActivity(Intent intent, String what) {
+        try {
+            mContext.startActivityAsUser(intent, UserHandle.CURRENT);
+            Slog.i(TAG, "top button -> " + what);
+            return true;
+        } catch (ActivityNotFoundException e) {
+            return false;
+        } catch (Exception e) {
+            Slog.w(TAG, "top button -> " + what + " failed", e);
+            return false;
+        }
+    }
+
+    private int getSetting(String key, int def) {
+        return Settings.System.getIntForUser(mContext.getContentResolver(), key, def,
+                UserHandle.USER_CURRENT);
+    }
+
+    private void putSetting(String key, int value) {
+        Settings.System.putIntForUser(mContext.getContentResolver(), key, value,
+                UserHandle.USER_CURRENT);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Full rationale: [`docs/rom-choice.md`](docs/rom-choice.md).
 | Amber frontlight | rootless system app: Quick-Settings tile + slider, mirrors `screen_brightness_amber_rate` → kernel LED (auto-discovers the node; override via `ro.dc1.amber.node`) | `AmberControl/` |
 | SELinux | lets the amber app (`platform_app` domain) read/write `sysfs_leds` under enforcing policy — TE allow plus `mlstrustedobject` on `sysfs_leds`, see [`docs/amber.md`](docs/amber.md) | `sepolicy/dc1amber.te` |
 | Priv-app permission | allows `WRITE_SETTINGS` to the amber app | `privapp-permissions-dc1.xml` |
+| Hardware buttons | `DeviceKeyHandler` restoring the two dead physical buttons: orange (`KEY_F11`) toggles the amber frontlight, top (`KEY_F12`) opens the Notes-role app — neither keycode has a default action in AOSP/LineageOS, see [`docs/buttons.md`](docs/buttons.md) | `DC1KeyHandler/`, `overlay-lineage/` |
 | Display/feature config | monochrome-panel + no-camera/no-light-sensor/no-telephony feature masks, forced grayscale + 1184x1584 size props, drops camera apps; setup wizard kept, its SIM step self-skips | `rro/`, `dc1-excluded-hardware.xml`, `common.mk` |
 | Repo manifest | adds `vendor/dc1` (this repo) to the build tree | `local_manifests/dc1.xml` |
 
@@ -47,6 +48,8 @@ in through `generate.sh vendor/dc1/common.mk`, plus the single small
 ```
 common.mk                  Product fragment (sycned into the tree as vendor/dc1/common.mk)
 AmberControl/              Rootless amber frontlight app (Java, platform-priv-app)
+DC1KeyHandler/             DeviceKeyHandler for the two physical buttons (F11/F12)
+overlay-lineage/           Build-time lineage-sdk overlay (registers the key handler)
 sepolicy/                  SELinux additions for the amber app (TE + MLS)
 privapp-permissions-dc1.xml
 dc1-excluded-hardware.xml  Masks camera + light-sensor features from stock /vendor

--- a/common.mk
+++ b/common.mk
@@ -55,6 +55,17 @@ SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += vendor/dc1/sepolicy
 PRODUCT_PACKAGES += \
     DC1Overlay
 
+# --- Hardware buttons: KEY_F11 (orange, side) + KEY_F12 (top) ---------------
+# Neither keycode has a default action in AOSP or LineageOS; on stock they
+# only worked because Daylight's own system apps listened for them, so on a
+# GSI both buttons are inert from the flash. DC1KeyHandler is loaded by
+# LineageOS' PhoneWindowManager through config_deviceKeyHandlerLibs, which the
+# lineage-sdk overlay below sets. See docs/buttons.md.
+PRODUCT_PACKAGES += \
+    DC1KeyHandler
+
+PRODUCT_PACKAGE_OVERLAYS += vendor/dc1/overlay-lineage
+
 # --- Mask camera + light-sensor features declared by the stock /vendor ------
 PRODUCT_COPY_FILES += \
     vendor/dc1/dc1-excluded-hardware.xml:$(TARGET_COPY_OUT_SYSTEM_EXT)/etc/permissions/dc1-excluded-hardware.xml

--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -1,0 +1,93 @@
+# The two hardware buttons
+
+The DC-1 has two physical buttons besides power and volume — the **orange one
+on the side** and the **top** one. On any GSI both are dead, and it isn't
+obvious why: nothing in the ROM is broken, the keys simply have nowhere to go.
+
+## Why they go inert on a GSI
+
+`mtk-kpd` (`/dev/input/event1`) exposes them as plain function keys, and
+`/vendor/usr/keylayout/mtk-kpd.kl` maps scancodes 87 and 88:
+
+| button | scancode | keycode |
+|---|---|---|
+| orange, side | 87 | `KEY_F11` (141) |
+| top | 88 | `KEY_F12` (142) |
+
+**Neither F11 nor F12 has any default action in AOSP or LineageOS.** On stock
+they worked only because Daylight's own privileged app
+(`com.daylightcomputer.systemrunner`) listened for them — and that app is one
+of the things a GSI replaces. So the buttons stop working the moment you
+flash, with no error anywhere to explain it.
+
+## What they did on stock
+
+Recovered by pulling `SystemRunner.apk` out of the stock OTA's `system.img`
+with `debugfs` (system-as-root ext4, no mount needed) and disassembling
+`KeyHandler.handleKeyEvent`.
+
+Worth care if you repeat this: the branch offsets **invert the obvious reading
+order**, so the disassembly listing alone attributes the wrong action to each
+key. Resolved against offsets — `if-eq 141` at 0019 jumps +0x0b to **0030**,
+`if-eq 142` at 0023 jumps +3 to **0026**:
+
+- **F11 (orange, side)** only ever showed a toast: *"Walkie-Talkie assistant
+  is coming soon!"* — a stub for a feature Daylight never shipped. There is no
+  real behaviour to be faithful to, so the button is free.
+- **F12 (top)** called `handleTopButton()`, launching
+  `com.fluidtouch.noteshelf2`, falling back to `noteshelf3`, else toasting
+  "No note-taking app found".
+
+## What this fork binds them to
+
+`DC1KeyHandler` — a small `DeviceKeyHandler` loaded by LineageOS'
+`PhoneWindowManager` via `config_deviceKeyHandlerLibs` (set in
+`overlay-lineage/`). No root, no new daemon, nothing to keep running.
+
+- **Orange (F11) → toggle the amber frontlight**, between off and the last
+  warmth used (remembered in `dc1_amber_last_rate`). It moves AmberControl's
+  own setting rather than touching the LED nodes, so the channel model, node
+  discovery and the watchdog all still apply — the button is just a second
+  way to move the same input as the QS tile. A physical control you can find
+  in the dark beats a tile in the pull-down shade on a bedside reader.
+- **Top (F12) → open notes**, generalising what Daylight hardcoded: an
+  explicit override if set, else Android's **Notes role**
+  (`ACTION_CREATE_NOTE` — whatever the user picked as their default notes
+  app), else the two Noteshelf packages for stock parity.
+
+Both are handled only while the display is interactive, and both key events
+are consumed so apps never see a stray F11/F12.
+
+The override for the top button is a plain setting:
+
+```bash
+adb shell settings put system dc1_notes_package com.example.notes
+adb shell settings delete system dc1_notes_package      # back to the Notes role
+```
+
+## Testing a button without pressing it
+
+`input keyevent` does **not** work here — it injects above the input device,
+so a device key handler reading real hardware events never sees it, and
+neither does `getevent`. Inject the raw scancode instead:
+
+```bash
+# key down + sync, then key up + sync  (87 = orange, 88 = top)
+adb shell 'sendevent /dev/input/event1 1 87 1; sendevent /dev/input/event1 0 0 0'
+adb shell 'sendevent /dev/input/event1 1 87 0; sendevent /dev/input/event1 0 0 0'
+
+adb logcat -s DC1KeyHandler
+```
+
+## If they stay dead
+
+The handler logs nothing until a key arrives, so check the load first:
+
+```bash
+adb shell dumpsys window | grep -i keyhandler     # or:
+adb logcat -b all | grep -i "device key handler"  # PWM logs instantiation failures
+adb shell ls -l /system_ext/app/DC1KeyHandler/DC1KeyHandler.apk
+```
+
+`PhoneWindowManager` catches and logs any exception from the constructor, so a
+handler that fails to load fails silently from the user's point of view.

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -49,6 +49,19 @@ MediaTek-flavored GSIs (TrebleDroid) behave well here.
   `ro.dc1.amber.node=/sys/class/leds/<node>/brightness` in the ROM; the app
   also auto-discovers the node on first boot.
 
+## Hardware buttons
+
+Besides power and volume the DC-1 has two buttons, both on `mtk-kpd`
+(`/dev/input/event1`), mapped by `/vendor/usr/keylayout/mtk-kpd.kl`:
+
+| button | scancode | keycode | stock behaviour |
+|---|---|---|---|
+| orange, side | 87 | `KEY_F11` (141) | a toast, "Walkie-Talkie assistant is coming soon!" — a stub for an unshipped feature |
+| top | 88 | `KEY_F12` (142) | launch Noteshelf 2, else Noteshelf 3, else "No note-taking app found" |
+
+Neither keycode has a default action in AOSP or LineageOS, so on a GSI both go
+inert unless something handles them: see [`docs/buttons.md`](buttons.md).
+
 ## Software stack (stock, for reference)
 
 | Package | Location | Role |

--- a/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
+++ b/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Hand KEY_F11 / KEY_F12 (the DC-1's two physical buttons) to
+         DC1KeyHandler. Neither keycode has a default action in AOSP or
+         LineageOS, so without this both buttons are inert. See
+         docs/buttons.md. -->
+    <string-array name="config_deviceKeyHandlerLibs" translatable="false">
+        <item>/system_ext/app/DC1KeyHandler/DC1KeyHandler.apk</item>
+    </string-array>
+
+    <string-array name="config_deviceKeyHandlerClasses" translatable="false">
+        <item>com.dc1.keyhandler.KeyHandler</item>
+    </string-array>
+</resources>

--- a/tools/validate-fork.sh
+++ b/tools/validate-fork.sh
@@ -62,6 +62,9 @@ for ref in \
   rro/DC1Overlay/Android.bp \
   rro/DC1Overlay/AndroidManifest.xml \
   rro/DC1Overlay/res/values/config.xml \
+  DC1KeyHandler/Android.bp \
+  DC1KeyHandler/AndroidManifest.xml \
+  overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml \
   local_manifests/dc1.xml; do
   [ -e "$ROOT/$ref" ] || fail "common.mk references missing file: $ref"
   ok "$ref"
@@ -74,6 +77,8 @@ if command -v xmllint >/dev/null 2>&1; then
     dc1-excluded-hardware.xml \
     rro/DC1Overlay/AndroidManifest.xml \
     rro/DC1Overlay/res/values/config.xml \
+    DC1KeyHandler/AndroidManifest.xml \
+    overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml \
     local_manifests/dc1.xml; do
     xmllint --noout "$ROOT/$x" || fail "malformed XML: $x"
     ok "well-formed: $x"


### PR DESCRIPTION
From #4 (section 2) — the substantive one.

## The problem

The orange side button and the top button emit `KEY_F11` / `KEY_F12` on `mtk-kpd` (`/vendor/usr/keylayout/mtk-kpd.kl` maps scancodes 87/88). **Neither keycode has a default action in AOSP or LineageOS.** On stock they worked only because `com.daylightcomputer.systemrunner` listened for them — and that's one of the apps a GSI replaces. So both buttons are inert from the flash onward, with nothing logged to explain why.

## The shape

`DC1KeyHandler`, a `DeviceKeyHandler` loaded by `PhoneWindowManager` via `config_deviceKeyHandlerLibs` (`overlay-lineage/`) — the same wiring LineageOS device trees already use. No root, no daemon, no extra process; the class runs inside system_server.

- **Orange (F11) → toggle the amber frontlight** between off and the last warmth used. It moves **AmberControl's own `Settings.System` key**, not the LED nodes, so node discovery, your channel model and the watchdog all keep applying — the button is just a second way to move the same input as the QS tile, with no second mechanism to keep in sync. It reads `ro.dc1.amber.setting` / `ro.dc1.amber.max` so it can't disagree with the product fragment about key name or scale.
- **Top (F12) → open notes**, generalising what Daylight hardcoded: an explicit override (`dc1_notes_package`), else Android's Notes role (`ACTION_CREATE_NOTE`), else the two Noteshelf packages for stock parity.

Both keycodes are consumed so no stray F11/F12 reaches apps; both act only on the initial down, only while the display is interactive, and the work runs on the handler's own thread rather than the input path.

## Why binding F11 to amber overrides nothing

I pulled `SystemRunner.apk` out of the stock OTA's `system.img` with `debugfs` and disassembled `KeyHandler.handleKeyEvent`. **Care needed if you repeat this:** the branch offsets invert the obvious reading order, so the listing alone attributes the wrong action to each key. Resolved against offsets (`if-eq 141` @0019 → **0030**, `if-eq 142` @0023 → **0026**):

- **F11** only ever showed a toast — *"Walkie-Talkie assistant is coming soon!"*, a stub for a feature Daylight never shipped. Nothing to be faithful to.
- **F12** called `handleTopButton()` → `noteshelf2`, else `noteshelf3`, else a toast.

## What I verified, and what I didn't

Verified on hardware here: the scancode/keycode mapping, that both keys are inert on the GSI, the recovered stock behaviour, and the two bindings themselves — though **mine run from a root daemon in a Magisk module, not from this code**. My install is the upstream MisterZtr GSI plus a Magisk delta, so I can't boot your image.

So: **this handler is not exercised in-image.** I checked what I could statically — the `DeviceKeyHandler` contract against `lineage-23.2` (the array form `config_deviceKeyHandlerLibs`/`Classes`, `PathClassLoader`, `Context` constructor, return-null-to-consume), the `Settings.System.{get,put}IntForUser` / `getStringForUser` signatures, `Intent.ACTION_CREATE_NOTE`, `Context.startActivityAsUser`, and `tools/validate-fork.sh` passes with the new files added to its manifest — but it has never been compiled in a real tree or run on a device. Please treat it as a reviewed proposal rather than tested code.

Validating it should be quick, and `docs/buttons.md` has the recipe. One detail that will save you time: **`input keyevent` does not work** for this — it injects above the input device, so a device key handler never sees it. Use `sendevent` with the raw scancode:

```bash
adb shell 'sendevent /dev/input/event1 1 87 1; sendevent /dev/input/event1 0 0 0'
adb shell 'sendevent /dev/input/event1 1 87 0; sendevent /dev/input/event1 0 0 0'
adb logcat -s DC1KeyHandler
```

## Notes

- I deliberately did **not** propose a keylayout override — the mapping lives in `/vendor/usr/keylayout/mtk-kpd.kl` and I never tested whether a system-side file can shadow it.
- `overlay-lineage/` is a build-time overlay (`PRODUCT_PACKAGE_OVERLAYS`) because that's what every LineageOS device tree does for lineage-sdk resources. If you'd rather keep everything as RROs, an RRO targeting `org.lineageos.platform` should work too — say the word and I'll rework it.
- Happy to split the docs out if you want the code and the write-up reviewed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3XjQzaexaB1vA8UsvEUx3